### PR TITLE
fix(auth): use x-access-token username for HTTPS clone URLs

### DIFF
--- a/templatron/repo/base_repo.py
+++ b/templatron/repo/base_repo.py
@@ -52,7 +52,7 @@ class BaseRepo(object):
 
     @property
     def clone_url(self):
-        return self.github.clone_url.replace("github.com", f"{self.token}@github.com")
+        return self.github.clone_url.replace("github.com", f"x-access-token:{self.token}@github.com")
 
     @property
     def head(self):

--- a/test/test_repo/test_base_repo.py
+++ b/test/test_repo/test_base_repo.py
@@ -97,7 +97,7 @@ class TestBaseRepo(TestCase):
         self.test_repo.clone_url  # pylint: disable=pointless-statement
         self.test_repo.github.clone_url.replace.assert_called_with(
             "github.com",
-            "fake_token@github.com",
+            "x-access-token:fake_token@github.com",
         )
 
     def test_head(self):


### PR DESCRIPTION
## Problem

I'm leveraging a GitHub App token for my authentication, but GItHub requires a slightly different format when using this token, so currently my workflow is failing.

Current HTTPS clone URLs is `https://<TOKEN>@github.com/owner/repo.git` (`templatron/repo/base_repo.py:55`). That format works for classic and fine-grained PATs, but for GitHub App installation tokens (`ghs_...`)GitHub requires the literal username `x-access-token` and the token as the password.

In my current workflow I'm getting this error:

```
fatal: could not read Password for 'https://***@github.com': No such device or address
```

### Reproduction

```bash
TOKEN="<any ghs_… installation token>"

# current format — fails
git clone "https://${TOKEN}@github.com/some/repo.git"
# → fatal: could not read Password for 'https://***@github.com'

# x-access-token form — succeeds
git clone "https://x-access-token:${TOKEN}@github.com/some/repo.git"
```

## Fix

Prepending `x-access-token:` as the user to the token in the embedded URL should be a backwards-compatible change for every GitHub token type.
