### PR TITLE
Improve error handling and parsing for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,23 +125,29 @@ runtime. The others are core to `git` and can not be changed.
 $ templatron --help
 Usage: templatron [OPTIONS] TEMPLATE COMMAND [ARGS]...
 
+  TEMPLATE is the source template repo, accepted as 'org/name', a bare name
+  (org from config), or a clone URL (SSH or HTTPS, with or without '.git').
+
 Options:
   --autoclean / --no-autoclean    remove clones from disk after running
   -r, --clone-root TEXT           path to clone repos
   -d, --dry-run                   don't push changes to cloned repos
+  -i, --interactive               run in interactive mode to be asked
+                                  onboarding questions
+  -l, --log-level TEXT
+  --logging-config FILE           path to logging_config.yaml
   -b, --template-branch TEXT      branch of the template to sync from
   -t, --template-config TEXT      path inside the template repo where its
                                   config is stored
   -e, --token-variable-name TEXT  name of the environment variable storing the
                                   GitHub token
-  -l, --log-level TEXT
-  --logging-config FILE           path to logging_config.yaml
   --config FILE                   Read configuration from FILE.
   --version                       Show the version and exit.
   --help                          Show this message and exit.
 
 Commands:
-  onboard  onboard a repo to be updated by a template
+  fix      fix an existing template PR
+  onboard  onboard a repo to be updated by a template.
   update   update repos already configured for a template
 ```
 
@@ -221,6 +227,14 @@ repos:
       org: a-different-github-org
   - a-third-github-org/some-other-repo
 ```
+
+Anywhere a repo identifier is accepted — the `TEMPLATE` argument, the `onboard` repo argument, and entries in the template config — these forms all resolve identically:
+
+- `org/name`
+- `name` (org comes from the template config default)
+- `git@github.com:org/name.git`
+- `https://github.com/org/name(.git)?`
+- `ssh://git@github.com/org/name(.git)?`
 
 ## Hooks
 

--- a/templatron/cli.py
+++ b/templatron/cli.py
@@ -12,7 +12,13 @@ from templatron.config.click_yaml_provider import click_yaml_provider
 DEFAULT_CLONE_ROOT = os.path.join(gettempdir(), "templatron_clones")
 
 
-@click.group()
+@click.group(
+    help=(
+        "TEMPLATE is the source template repo, accepted as "
+        "'org/name', a bare name (org from config), or a clone URL "
+        "(SSH or HTTPS, with or without '.git')."
+    )
+)
 @click.pass_context
 @click.argument("template")
 @click.option(
@@ -99,7 +105,13 @@ def update(ctx, single_repo, cache):
     templatron.update(single_repo, cache)
 
 
-@main.command(help="onboard a repo to be updated by a template")
+@main.command(
+    help=(
+        "onboard a repo to be updated by a template. ONBOARDING_REPO "
+        "accepts the same forms as TEMPLATE: 'org/name', a bare name, "
+        "or a clone URL."
+    )
+)
 @click.pass_context
 @click.argument("onboarding_repo")
 def onboard(ctx, onboarding_repo):

--- a/templatron/exceptions.py
+++ b/templatron/exceptions.py
@@ -22,6 +22,10 @@ class MissingRequiredConfigError(TemplatronException):
     pass
 
 
+class StaleCloneError(TemplatronException):
+    pass
+
+
 class TemplateConfigMissingError(TemplatronException):
     pass
 

--- a/templatron/repo/base_repo.py
+++ b/templatron/repo/base_repo.py
@@ -103,6 +103,13 @@ class BaseRepo(object):
             return git(cmd, *args)
         return git(cmd, *args, _cwd=self.clone_path)
 
+    def local_branch_exists(self, branch):
+        try:
+            self.git_cmd("rev-parse", "--verify", f"refs/heads/{branch}")
+            return True
+        except ErrorReturnCode:
+            return False
+
     def maybe_switch_branch(self):
         if self.active_branch == self.base_branch:
             return

--- a/templatron/repo/repository.py
+++ b/templatron/repo/repository.py
@@ -6,7 +6,7 @@ import yaml
 from copier import run_copy, run_update
 
 from templatron.commit_template import commit_template
-from templatron.exceptions import HookFailure
+from templatron.exceptions import HookFailure, StaleCloneError
 from templatron.log_or_print import log_or_print
 from templatron.repo.base_repo import BaseRepo
 
@@ -285,6 +285,14 @@ vcs_ref={self.template.vcs_ref})""")
             return
 
         self.logger.debug(f"switch to update branch {self.update_branch_name}")
+        if self.local_branch_exists(self.update_branch_name):
+            raise StaleCloneError(
+                f"branch '{self.update_branch_name}' already exists in "
+                f"{self.clone_path} — likely left behind by a previous "
+                "run that didn't clean up. Delete the clone directory "
+                "and retry, or pass --autoclean to remove clones "
+                "automatically."
+            )
         self.git_cmd("checkout", "-b", self.update_branch_name)
 
     def update(self, operation="updating"):

--- a/templatron/templatron.py
+++ b/templatron/templatron.py
@@ -181,7 +181,7 @@ class Templatron(object):
         try:
             repo = self.build_repo(onboarding_repo)
             repo.onboard()
-        except UnrecognizableBaseBranchError as error:
+        except TemplatronException as error:
             self.die(error)
         except KeyboardInterrupt:
             self.maybe_clean()

--- a/templatron/templatron.py
+++ b/templatron/templatron.py
@@ -249,6 +249,13 @@ class Templatron(object):
             org = parts[0]
             name = parts[1]
         else:
+            if self.template is None:
+                raise MissingRequiredConfigError(
+                    f"Cannot determine org for '{name}': the template "
+                    "config has not been loaded yet, so there is no "
+                    "default org to fall back on. Specify the template "
+                    "as '<org>/<name>' on the command line."
+                )
             org = self.template.config.org
             if org is None:
                 raise MissingRequiredConfigError(

--- a/templatron/templatron.py
+++ b/templatron/templatron.py
@@ -244,6 +244,18 @@ class Templatron(object):
         return return_list
 
     def split_org_and_name(self, name):
+        # Accept clone URLs (SSH or HTTPS) in addition to "org/name" or a
+        # bare name, since clone URLs are what GitHub's UI and `gh` print.
+        # SSH:   git@github.com:org/name(.git)?
+        # HTTPS: https://github.com/org/name(.git)?
+        # ssh:// git+ssh://git@github.com/org/name(.git)?
+        if name.startswith("git@") and ":" in name:
+            name = name.split(":", 1)[1]
+        elif "://" in name:
+            name = name.split("://", 1)[1].split("/", 1)[1]
+        if name.endswith(".git"):
+            name = name[: -len(".git")]
+
         parts = name.split("/")
         if len(parts) >= 2:
             org = parts[0]

--- a/test/test_repo/test_base_repo.py
+++ b/test/test_repo/test_base_repo.py
@@ -7,7 +7,7 @@ Unit tests for templatron/repo/base_repo.py
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from sh import ErrorReturnCode
+from sh import ErrorReturnCode, ErrorReturnCode_1
 
 from templatron.exceptions import DirtyRepoError, UnrecognizableBaseBranchError
 from templatron.repo.base_repo import BaseRepo
@@ -221,6 +221,30 @@ class TestBaseRepo(TestCase):
 
         self.test_repo.git_cmd("commit", "some args")
         mock_git.assert_called_with("commit", "some args", _cwd="/fake/root/fake repo")
+
+    @patch("templatron.repo.base_repo.BaseRepo.git_cmd")
+    def test_local_branch_exists_true(self, mock_git):
+        """
+        Test BaseRepo.local_branch_exists() returns True when
+        git rev-parse --verify succeeds.
+        """
+
+        self.assertTrue(self.test_repo.local_branch_exists("fake_branch"))
+        mock_git.assert_called_with(
+            "rev-parse", "--verify", "refs/heads/fake_branch"
+        )
+
+    @patch("templatron.repo.base_repo.BaseRepo.git_cmd")
+    def test_local_branch_exists_false(self, mock_git):
+        """
+        Test BaseRepo.local_branch_exists() returns False when
+        git rev-parse --verify exits non-zero (branch missing).
+        """
+
+        mock_git.side_effect = ErrorReturnCode_1(
+            full_cmd="git", stdout=b"", stderr=b""
+        )
+        self.assertFalse(self.test_repo.local_branch_exists("fake_branch"))
 
     @patch.object(BaseRepo, "active_branch", "fake_branch")
     @patch.object(BaseRepo, "base_branch", "fake_branch")

--- a/test/test_repo/test_repository.py
+++ b/test/test_repo/test_repository.py
@@ -8,7 +8,7 @@ Unit tests for templatron/repo/repository.py
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from templatron.exceptions import HookFailure
+from templatron.exceptions import HookFailure, StaleCloneError
 from templatron.repo.repository import Repository
 from templatron.repo.template import Template
 
@@ -470,15 +470,35 @@ class TestRepository(TestCase):
         mock_git.assert_not_called()
 
     @patch.object(Repository, "update_branch_name", "fake_branch")
+    @patch("templatron.repo.repository.Repository.local_branch_exists")
     @patch("templatron.repo.repository.Repository.git_cmd")
-    def test_switch_to_update_branch_not_fixing(self, mock_git):
+    def test_switch_to_update_branch_not_fixing(self, mock_git, mock_exists):
         """
         Docs
         """
 
+        mock_exists.return_value = False
         self.test_repo.operation = "not fixing"
         self.test_repo.switch_to_update_branch()
         mock_git.assert_called_with("checkout", "-b", "fake_branch")
+
+    @patch.object(Repository, "update_branch_name", "fake_branch")
+    @patch("templatron.repo.repository.Repository.local_branch_exists")
+    @patch("templatron.repo.repository.Repository.git_cmd")
+    def test_switch_to_update_branch_stale_branch(
+        self, mock_git, mock_exists
+    ):
+        """
+        Test switch_to_update_branch() raises StaleCloneError when the
+        target update branch already exists locally — typically from a
+        prior run that didn't clean up.
+        """
+
+        mock_exists.return_value = True
+        self.test_repo.operation = "not fixing"
+        with self.assertRaisesRegex(StaleCloneError, "fake_branch"):
+            self.test_repo.switch_to_update_branch()
+        mock_git.assert_not_called()
 
     @patch.object(Repository, "needs_update", True)
     @patch("templatron.repo.repository.Repository.clean_stale_branches")

--- a/test/test_templatron.py
+++ b/test/test_templatron.py
@@ -537,6 +537,42 @@ class TestFetchRepoList(TestCase):
         with self.assertRaises(MissingRequiredConfigError):
             self.templatron.split_org_and_name("fake_name")
 
+    def test_split_org_and_name_ssh_url(self):
+        """
+        Test Templatron.split_org_and_name() accepts SSH clone URLs.
+        """
+
+        self.assertEqual(
+            self.templatron.split_org_and_name(
+                "git@github.com:fake_org/fake_name.git"
+            ),
+            ("fake_org", "fake_name"),
+        )
+
+    def test_split_org_and_name_https_url(self):
+        """
+        Test Templatron.split_org_and_name() accepts HTTPS clone URLs.
+        """
+
+        self.assertEqual(
+            self.templatron.split_org_and_name(
+                "https://github.com/fake_org/fake_name.git"
+            ),
+            ("fake_org", "fake_name"),
+        )
+
+    def test_split_org_and_name_ssh_scheme_url(self):
+        """
+        Test Templatron.split_org_and_name() accepts ssh:// scheme URLs.
+        """
+
+        self.assertEqual(
+            self.templatron.split_org_and_name(
+                "ssh://git@github.com/fake_org/fake_name.git"
+            ),
+            ("fake_org", "fake_name"),
+        )
+
     def test_split_org_and_name_no_template(self):
         """
         Test Templatron.split_org_and_name() raises a clear config error

--- a/test/test_templatron.py
+++ b/test/test_templatron.py
@@ -15,6 +15,7 @@ from templatron.exceptions import (
     TemplatronException,
     GitConfigError,
     MissingRequiredConfigError,
+    StaleCloneError,
     UnrecognizableBaseBranchError,
 )
 from templatron.templatron import Templatron
@@ -470,6 +471,26 @@ class TestFetchRepoList(TestCase):
         """
 
         mock_build.side_effect = UnrecognizableBaseBranchError
+        mock_die.side_effect = SystemExit
+        with self.assertRaises(SystemExit):
+            self.templatron.onboard("repo")
+        mock_start.assert_called_with("onboarding")
+        mock_stop.assert_not_called()
+
+    @patch("templatron.templatron.Templatron.die")
+    @patch("templatron.templatron.Templatron.start")
+    @patch("templatron.templatron.Templatron.build_repo")
+    @patch("templatron.templatron.Templatron.stop")
+    def test_onboard_stale_clone(
+        self, mock_stop, mock_build, mock_start, mock_die
+    ):
+        """
+        Test Templatron.onboard() exits cleanly via die() when the
+        repo's update branch already exists from a prior run, rather
+        than letting the exception propagate as a raw traceback.
+        """
+
+        mock_build().onboard.side_effect = StaleCloneError("stale")
         mock_die.side_effect = SystemExit
         with self.assertRaises(SystemExit):
             self.templatron.onboard("repo")

--- a/test/test_templatron.py
+++ b/test/test_templatron.py
@@ -537,6 +537,20 @@ class TestFetchRepoList(TestCase):
         with self.assertRaises(MissingRequiredConfigError):
             self.templatron.split_org_and_name("fake_name")
 
+    def test_split_org_and_name_no_template(self):
+        """
+        Test Templatron.split_org_and_name() raises a clear config error
+        when called before self.template has been built — e.g. from
+        within build_template() itself when the user passed a bare
+        template name on the CLI.
+        """
+
+        self.templatron.template = None
+        with self.assertRaisesRegex(
+            MissingRequiredConfigError, "template.*has not been loaded"
+        ):
+            self.templatron.split_org_and_name("fake_name")
+
     @patch("templatron.templatron.Templatron.setup_logging")
     @patch("templatron.templatron.Templatron.maybe_log_dry_run")
     @patch("templatron.templatron.Templatron.validate_config")


### PR DESCRIPTION
For some reason my shell history had commands I thought I had working that were using the wrong arguments for templatron, and running the command kept giving me tracebacks.  So this PR includes a few fixes.

1. If no `org/name` is properly identified then throw a useful error
2. If a full git url is passed for either, parse it for the necessary components.
3. Return a better error if the tmp directories for stranded and user didn't pass `--autoclean`
4. Update the docs
