### PR TITLE
feat(cli): add --conflict-resolution to control copier merge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ Usage: templatron [OPTIONS] TEMPLATE COMMAND [ARGS]...
 Options:
   --autoclean / --no-autoclean    remove clones from disk after running
   -r, --clone-root TEXT           path to clone repos
+  -x, --conflict-resolution [manual|overwrite]
+                                  how copier should resolve conflicts during
+                                  an update. 'manual' leaves diff3 conflict
+                                  markers in the files; 'overwrite' takes the
+                                  template's version and discards copier's
+                                  .rej files. Unset means use copier's own
+                                  default.
   -d, --dry-run                   don't push changes to cloned repos
   -b, --template-branch TEXT      branch of the template to sync from
   -t, --template-config TEXT      path inside the template repo where its
@@ -160,6 +167,15 @@ Anything that can be passed to `templatron` via command line options can be conf
 - `clone-root`: (default: `/tmp/templatron_clones`) is the root directory where
   repos will be cloned. You **DO NOT** want this to be `$WORKDIR`, for
   the reasons stated in `autoclean` description.
+- `conflict-resolution`: (default: unset) how copier should resolve merge
+  conflicts during an update. Set to `manual` to leave diff3 conflict markers
+  in the files for a human to resolve in the resulting PR (equivalent to
+  copier's `--conflict=inline`). Set to `overwrite` to take the template's
+  version and discard the `.rej` files copier would otherwise drop next to
+  each conflicting file (equivalent to copier's `--conflict=rej`, with the
+  `.rej` files cleaned up before the commit). When unset, copier's own
+  default applies. The CLI flag overrides the value set in either yaml
+  config layer.
 - `dry-run`: (default: `false`) enable `dry-run` mode for all repos. `dry-run`
   mode is special and has its own configuration sub-section below.
 - `template-branch`: (default: `main` or `master` depending on which the template repo uses) which branch of the template should be checked out and run to update desintation repos
@@ -176,6 +192,11 @@ Lives in the template repo (default location `templatron.yaml`). Config options:
 - `autoscan`: (default: `False`) if enabled, `autoscan` clones every repo in the default `org` that isn't a fork, and isn't archived. if that repo has an `answers-file` it is added to the list of repos that will have the template run against them.
 - `branch-prefix`: (default: `templatron`) See Branch Names above
 - `branch-separator`: (default: `/`) See Branch Names above
+- `conflict-resolution`: (default: unset) how copier should resolve merge
+  conflicts during an update. `manual` leaves diff3 conflict markers in the
+  files; `overwrite` takes the template's version and discards copier's
+  `.rej` files. See the matching CLI option above for details. Can also be
+  set under a specific repo entry to override the template-wide default.
 - `dry-run`: (default: `False`) run `templatron` in dry-run mode
 - `hooks`: hooks can run scripts at certain points during the onboarding and / or updating operations. see [hooks](#hooks) for more details
 - `old-answers-files`: this is a `list` of answersfiles that _used to be, but are no longer used_. when running autoscan, `tempaltron` will run against a repo if the current answers file is missing, but one of the `old-answers-files` is present. You'll need to include a `pre-copier` hook to `git mv` the old answers file to the current location, or else your answers **WILL NOT** be loaded during the update.

--- a/templatron/cli.py
+++ b/templatron/cli.py
@@ -24,6 +24,21 @@ DEFAULT_CLONE_ROOT = os.path.join(gettempdir(), "templatron_clones")
     "--clone-root", "-r", default=DEFAULT_CLONE_ROOT, help="path to clone repos"
 )
 @click.option(
+    "--conflict-resolution",
+    "-x",
+    type=click.Choice(["manual", "overwrite"]),
+    default=None,
+    help=(
+        "how copier should resolve conflicts during an update: "
+        "'manual' leaves diff3 conflict markers in the files for a human "
+        "to resolve (copier --conflict=inline); "
+        "'overwrite' takes the template's version and discards the .rej "
+        "files copier would otherwise drop next to it "
+        "(copier --conflict=rej, with .rej cleanup). "
+        "When unset, copier's own default applies."
+    ),
+)
+@click.option(
     "--dry-run",
     "-d",
     default=False,
@@ -63,6 +78,7 @@ def main(
     template,
     autoclean,
     clone_root,
+    conflict_resolution,
     dry_run,
     template_branch,
     template_config,
@@ -76,6 +92,7 @@ def main(
         template=template,
         autoclean=autoclean,
         clone_root=clone_root,
+        conflict_resolution=conflict_resolution,
         dry_run=dry_run,
         template_branch=template_branch,
         template_config=template_config,

--- a/templatron/repo/repository.py
+++ b/templatron/repo/repository.py
@@ -1,6 +1,7 @@
 import logging
 import os.path
 import subprocess
+from pathlib import Path
 
 import yaml
 from copier import run_copy, run_update
@@ -9,6 +10,15 @@ from templatron.commit_template import commit_template
 from templatron.exceptions import HookFailure
 from templatron.log_or_print import log_or_print
 from templatron.repo.base_repo import BaseRepo
+
+# Map templatron's user-facing conflict-resolution names onto copier's
+# internal --conflict values. 'overwrite' uses copier's 'rej' mode and
+# we additionally strip the .rej files copier drops, since the templatron
+# PR workflow surfaces the diff for review on its own.
+CONFLICT_RESOLUTION_TO_COPIER = {
+    "manual": "inline",
+    "overwrite": "rej",
+}
 
 
 def string_representer(dumper, data):
@@ -40,6 +50,7 @@ class Repository(BaseRepo):
         answers_file=".copier-answers.yml",
         branch_prefix="templatron",
         branch_separator="/",
+        conflict_resolution=None,
         interactive=False,
         hooks=None,
     ):
@@ -51,6 +62,7 @@ class Repository(BaseRepo):
         self.answers_file = answers_file
         self.branch_prefix = branch_prefix
         self.branch_separator = branch_separator
+        self.conflict_resolution = conflict_resolution
         self.hooks = hooks or {}
 
         self.operation = None
@@ -222,13 +234,7 @@ class Repository(BaseRepo):
         # this is a no-op if it's already been cloned
 
         if self.operation == "updating":
-            self.logger.debug(f"""running copier to apply template...
-
-run_update({self.template.clone_path}, {self.clone_path},
-answers_file={self.answers_file}, overwrite=True, quiet={quiet},
-vcs_ref={self.template.vcs_ref})""")
-
-            run_update(
+            update_kwargs = dict(
                 dst_path=self.clone_path,
                 answers_file=self.answers_file,
                 defaults=True,
@@ -236,6 +242,22 @@ vcs_ref={self.template.vcs_ref})""")
                 quiet=quiet,
                 vcs_ref=self.template.vcs_ref,
             )
+            if self.conflict_resolution is not None:
+                update_kwargs["conflict"] = CONFLICT_RESOLUTION_TO_COPIER[
+                    self.conflict_resolution
+                ]
+
+            self.logger.debug(f"""running copier to apply template...
+
+run_update({self.template.clone_path}, {self.clone_path},
+answers_file={self.answers_file}, overwrite=True, quiet={quiet},
+vcs_ref={self.template.vcs_ref},
+conflict={update_kwargs.get("conflict")})""")
+
+            run_update(**update_kwargs)
+
+            if self.conflict_resolution == "overwrite":
+                self._strip_rej_files()
 
         else:  # onboarding or fixing
             self.logger.debug(f"""running copier to apply template...
@@ -278,6 +300,15 @@ vcs_ref={self.template.vcs_ref})""")
             raise HookFailure(
                 f"{hook_name} hook {hook} failed with exit code {res.returncode}"
             )
+
+    def _strip_rej_files(self):
+        # copier --conflict=rej drops .rej files next to any file it couldn't
+        # cleanly merge. The templatron PR carries the template's version and
+        # surfaces the diff for review on its own, so the .rej files are just
+        # noise that would otherwise be staged by `git add -A`.
+        for rej in Path(self.clone_path).rglob("*.rej"):
+            self.logger.debug(f"removing copier reject file: {rej}")
+            rej.unlink()
 
     def switch_to_update_branch(self):
         if self.fixing:

--- a/templatron/templatron.py
+++ b/templatron/templatron.py
@@ -357,6 +357,7 @@ class Templatron(object):
             "answers_file",
             "branch_prefix",
             "branch_separator",
+            "conflict_resolution",
             "dry_run",
             "hooks",
         ]:
@@ -369,6 +370,10 @@ class Templatron(object):
         # force interactive if it's enabled globally
         if self.config.interactive:
             kwargs["interactive"] = True
+
+        # CLI --conflict-resolution overrides template/per-repo config
+        if self.config.conflict_resolution is not None:
+            kwargs["conflict_resolution"] = self.config.conflict_resolution
 
         # this doesn't actually get passed to the Repository object,
         # so pull it out of kwargs

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -39,6 +39,51 @@ class TestUpdate(TestCase):
         self.runner.invoke(main, ["template", "update", "-1", "single_repo"])
         mock_templatron().update.assert_called_with("single_repo", None)
 
+    @patch("templatron.cli.Templatron")
+    def test_conflict_resolution_defaults_none(self, mock_templatron):
+        """
+        Without --conflict-resolution, Templatron is constructed with
+        conflict_resolution=None so copier's own default applies.
+        """
+
+        self.runner.invoke(main, ["template", "update"])
+        kwargs = mock_templatron.call_args.kwargs
+        self.assertIsNone(kwargs["conflict_resolution"])
+
+    @patch("templatron.cli.Templatron")
+    def test_conflict_resolution_overwrite(self, mock_templatron):
+        """
+        --conflict-resolution overwrite reaches Templatron(...).
+        """
+
+        self.runner.invoke(
+            main, ["--conflict-resolution", "overwrite", "template", "update"]
+        )
+        kwargs = mock_templatron.call_args.kwargs
+        self.assertEqual(kwargs["conflict_resolution"], "overwrite")
+
+    @patch("templatron.cli.Templatron")
+    def test_conflict_resolution_short_flag(self, mock_templatron):
+        """
+        -x is the short form of --conflict-resolution.
+        """
+
+        self.runner.invoke(main, ["-x", "manual", "template", "update"])
+        kwargs = mock_templatron.call_args.kwargs
+        self.assertEqual(kwargs["conflict_resolution"], "manual")
+
+    @patch("templatron.cli.Templatron")
+    def test_conflict_resolution_rejects_invalid(self, mock_templatron):
+        """
+        click rejects any value outside the manual/overwrite choice set.
+        """
+
+        res = self.runner.invoke(
+            main, ["--conflict-resolution", "nope", "template", "update"]
+        )
+        self.assertEqual(res.exit_code, 2)
+        mock_templatron().update.assert_not_called()
+
 
 class TestOnboard(TestCase):
     """

--- a/test/test_repo/test_repository.py
+++ b/test/test_repo/test_repository.py
@@ -5,6 +5,7 @@ Unit tests for templatron/repo/repository.py
 # pylint: disable=protected-access,too-many-arguments,too-many-public-methods
 # pylint: disable=unused-argument
 
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -404,6 +405,107 @@ class TestRepository(TestCase):
             overwrite=True,
             vcs_ref=None,
         )
+
+    @patch("templatron.repo.repository.run_update")
+    @patch("templatron.repo.template.Template.clone")
+    def test_run_copier_conflict_resolution_manual(self, mock_clone, mock_copy):
+        """
+        Test Repository.run_copier() forwards conflict='inline' to copier
+        when conflict_resolution is 'manual'.
+        """
+
+        def noop():
+            return
+
+        self.test_repo.interactive = False
+        self.test_repo.operation = "updating"
+        self.test_repo.conflict_resolution = "manual"
+        self.test_repo.pretty_print_answers_file = noop
+        self.test_repo.run_copier()
+        mock_copy.assert_called_with(
+            dst_path="/fake/root/fake repo",
+            answers_file=".copier-answers.yml",
+            defaults=True,
+            quiet=True,
+            overwrite=True,
+            vcs_ref=None,
+            conflict="inline",
+        )
+
+    @patch("templatron.repo.repository.Repository._strip_rej_files")
+    @patch("templatron.repo.repository.run_update")
+    @patch("templatron.repo.template.Template.clone")
+    def test_run_copier_conflict_resolution_overwrite(
+        self, mock_clone, mock_copy, mock_strip
+    ):
+        """
+        Test Repository.run_copier() forwards conflict='rej' to copier and
+        cleans up .rej files when conflict_resolution is 'overwrite'.
+        """
+
+        def noop():
+            return
+
+        self.test_repo.interactive = False
+        self.test_repo.operation = "updating"
+        self.test_repo.conflict_resolution = "overwrite"
+        self.test_repo.pretty_print_answers_file = noop
+        self.test_repo.run_copier()
+        mock_copy.assert_called_with(
+            dst_path="/fake/root/fake repo",
+            answers_file=".copier-answers.yml",
+            defaults=True,
+            quiet=True,
+            overwrite=True,
+            vcs_ref=None,
+            conflict="rej",
+        )
+        mock_strip.assert_called_once()
+
+    @patch("templatron.repo.repository.Repository._strip_rej_files")
+    @patch("templatron.repo.repository.run_update")
+    @patch("templatron.repo.template.Template.clone")
+    def test_run_copier_no_rej_cleanup_when_manual(
+        self, mock_clone, mock_copy, mock_strip
+    ):
+        """
+        Test Repository.run_copier() does NOT call _strip_rej_files when
+        conflict_resolution is 'manual'.
+        """
+
+        def noop():
+            return
+
+        self.test_repo.interactive = False
+        self.test_repo.operation = "updating"
+        self.test_repo.conflict_resolution = "manual"
+        self.test_repo.pretty_print_answers_file = noop
+        self.test_repo.run_copier()
+        mock_strip.assert_not_called()
+
+    def test_strip_rej_files(self):
+        """
+        Test Repository._strip_rej_files removes .rej files anywhere under
+        clone_path while leaving other files alone.
+        """
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            (tmp_path / "keep.txt").write_text("keep me")
+            (tmp_path / "a.rej").write_text("reject a")
+            nested = tmp_path / "deeply" / "nested"
+            nested.mkdir(parents=True)
+            (nested / "b.rej").write_text("reject b")
+            (nested / "keep.py").write_text("keep me too")
+
+            self.test_repo.clone_path = str(tmp_path)
+            self.test_repo.logger = MagicMock()
+            self.test_repo._strip_rej_files()
+
+            remaining = sorted(p.name for p in tmp_path.rglob("*") if p.is_file())
+            self.assertEqual(remaining, ["keep.py", "keep.txt"])
 
     @patch("templatron.repo.repository.subprocess.run")
     def test_run_hook_successful(self, mock_run):

--- a/test/test_templatron.py
+++ b/test/test_templatron.py
@@ -733,6 +733,7 @@ class TestFetchRepoList(TestCase):
             "answers_file",
             "branch_prefix",
             "branch_separator",
+            "conflict_resolution",
             "dry_run",
             "hooks",
         ]
@@ -740,6 +741,7 @@ class TestFetchRepoList(TestCase):
             "answers_file": "answers_file",
             "branch_prefix": "branch_prefix",
             "branch_separator": "branch_separator",
+            "conflict_resolution": "conflict_resolution",
             "dry_run": "dry_run",
             "hooks": "hooks",
         }
@@ -764,6 +766,7 @@ class TestFetchRepoList(TestCase):
             "answers_file",
             "branch_prefix",
             "branch_separator",
+            "conflict_resolution",
             "dry_run",
             "hooks",
         ]
@@ -771,6 +774,7 @@ class TestFetchRepoList(TestCase):
             "answers_file": "answers_file",
             "branch_prefix": "branch_prefix",
             "branch_separator": "branch_separator",
+            "conflict_resolution": "conflict_resolution",
             "dry_run": "dry_run",
             "hooks": "hooks",
         }
@@ -795,6 +799,26 @@ class TestFetchRepoList(TestCase):
             self.templatron.validate_repo("fake_repo")
 
     @patch("templatron.templatron.Templatron.split_org_and_name")
+    def test_validate_repo_conflict_resolution_cli_wins(self, mock_split):
+        """
+        Test Templatron.validate_repo() where --conflict-resolution on the
+        CLI overrides whatever the template config provides.
+        """
+
+        mock_split.return_value = ("fake_org", "fake_repo")
+        self.templatron.config.set("conflict_resolution", "overwrite")
+        self.templatron.template.config.get.side_effect = [
+            "answers_file",
+            "branch_prefix",
+            "branch_separator",
+            "manual",
+            "dry_run",
+            "hooks",
+        ]
+        _, _, kwargs = self.templatron.validate_repo("fake_org/fake_repo")
+        self.assertEqual(kwargs["conflict_resolution"], "overwrite")
+
+    @patch("templatron.templatron.Templatron.split_org_and_name")
     def test_validate_repo_global_force(self, mock_split):
         """
         Test Templatron.validate_repo() where dry_run or interactive
@@ -813,6 +837,7 @@ class TestFetchRepoList(TestCase):
             "answers_file",
             "branch_prefix",
             "branch_separator",
+            "conflict_resolution",
             "dry_run",
             "hooks",
         ]
@@ -820,6 +845,7 @@ class TestFetchRepoList(TestCase):
             "answers_file": "answers_file",
             "branch_prefix": "branch_prefix",
             "branch_separator": "branch_separator",
+            "conflict_resolution": "conflict_resolution",
             "dry_run": True,
             "hooks": "hooks",
             "interactive": True,


### PR DESCRIPTION
## Summary

Adds a new `-x/--conflict-resolution` option that lets templatron consumers tell copier how to behave when an update finds a file has been edited downstream. Two values:

- `manual` → copier `--conflict=inline` (today's default — diff3 markers in the files, human resolves in the PR)
- `overwrite` → copier `--conflict=rej`, **plus** templatron deletes the `.rej` files copier drops alongside each conflicting file before staging the commit. The PR carries the template's version of the file, and the PR's own diff is the review surface — the `.rej` files would otherwise be noise on every update.

Also accepted in `templatron.yaml` (template-wide) and in each repo's entry under `repos:` (per-repo override). Precedence is **CLI > per-repo > template-wide > copier's own default**. Leaving every layer unset is identical to today's behavior, so the change is non-breaking.

## Why these names instead of copier's

`inline` / `rej` describe copier's mechanism; `manual` / `overwrite` describe the *user's intent* with respect to the templatron PR flow. The whole point of the option is to choose how downstream drift surfaces in the PR, so naming it after that choice felt clearer than exposing copier's vocabulary.

## Test plan

- [x] `poetry run pytest` → 144 passed (was 135, +9 new tests)
- [x] `poetry run black --check .` clean
- [x] New unit coverage:
  - CLI option presence + short flag + invalid-choice rejection + default `None`
  - `validate_repo` precedence: CLI overrides template config
  - `run_copier` forwards `conflict="inline"` for `manual` and `conflict="rej"` for `overwrite`
  - `run_copier` only invokes `.rej` cleanup when `overwrite` is selected
  - `_strip_rej_files` actually removes `*.rej` recursively and leaves everything else alone
- [x] README updated for the CLI option, the `--config` yaml layer, and the template-config yaml layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)